### PR TITLE
Add WP PHPCS and apply auto fixable changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/comment-saver.php
+++ b/comment-saver.php
@@ -10,37 +10,37 @@ License: Dual GPL (http://www.fsf.org/licensing/licenses/info/GPLv2.html) and Mo
 */
 
 
-add_action('comment_form', 'comment_saver_form');
-add_filter('comment_post_redirect', 'comment_saver_cleanup', 10, 2);
-add_action('wp', 'comment_saver_js');
+add_action( 'comment_form', 'comment_saver_form' );
+add_filter( 'comment_post_redirect', 'comment_saver_cleanup', 10, 2 );
+add_action( 'wp', 'comment_saver_js' );
 
 
-/** 
- * Get path for comment saver cookie. 
+/**
+ * Get path for comment saver cookie.
  */
 function comment_saver_cookie_path() {
-	$parts = parse_url(get_option('home'));
-	$path = array_key_exists('path', $parts) ? $parts['path'] : '/';
+	$parts = parse_url( get_option( 'home' ) );
+	$path  = array_key_exists( 'path', $parts ) ? $parts['path'] : '/';
 	return $path;
 }
 
 
-/** 
- * Setup require javascript. 
+/**
+ * Setup require javascript.
  */
 function comment_saver_js() {
-	if (is_single() || is_comments_popup()) {
-		wp_enqueue_script('jquery.cookie', plugins_url('comment-saver/jquery.cookie.min.js'), array('jquery'), false, true);
+	if ( is_single() || is_comments_popup() ) {
+		wp_enqueue_script( 'jquery.cookie', plugins_url( 'comment-saver/jquery.cookie.min.js' ), array( 'jquery' ), false, true );
 	}
 }
 
 
-/** 
- * Add jQuery actions to save and restore comment. 
+/**
+ * Add jQuery actions to save and restore comment.
  */
-function comment_saver_form($id) { 
+function comment_saver_form( $id ) {
 	$cookieName = 'comment_saver_post' . $id;
-	$path = comment_saver_cookie_path();
+	$path       = comment_saver_cookie_path();
 
 	echo '
 	<script type="text/javascript">
@@ -62,10 +62,10 @@ function comment_saver_form($id) {
 /**
  * Cleanup comment saver cookie.
  */
-function comment_saver_cleanup($location, $comment) {
+function comment_saver_cleanup( $location, $comment ) {
 	$path = comment_saver_cookie_path();
-	setcookie('comment_saver_post' . $comment->comment_post_ID, null, -1, $path);
+	setcookie( 'comment_saver_post' . $comment->comment_post_ID, null, -1, $path );
 	return $location;
 }
 
-?>
+

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "allow-plugins": {
             "ergebnis/composer-normalize": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        },
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,10 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "ergebnis/composer-normalize": "^2.28",
         "wp-coding-standards/wpcs": "^2.3"
     },
     "config": {
         "allow-plugins": {
-            "ergebnis/composer-normalize": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "willnorris/comment-saver",
+    "description": "Saves comment text in a temporary cookie before it is submitted.",
+    "license": "GPL-2.0-or-later",
+    "type": "wordpress-plugin",
+    "authors": [
+        {
+            "name": "Will Norris",
+            "email": "will@willnorris.com",
+            "homepage": "https://willnorris.com/",
+            "role": "Developer"
+        }
+    ],
+    "homepage": "https://wordpress.org/plugins/comment-saver/",
+    "require": {
+        "php": "^5.6 || 7.* || >=8.0 <8.3"
+    },
+    "require-dev": {
+        "ergebnis/composer-normalize": "^2.28"
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,14 @@
         "php": "^5.6 || 7.* || >=8.0 <8.3"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "^2.28"
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "ergebnis/composer-normalize": "^2.28",
+        "wp-coding-standards/wpcs": "^2.3"
     },
     "config": {
         "allow-plugins": {
-            "ergebnis/composer-normalize": true
+            "ergebnis/composer-normalize": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset>
+    <file>.</file>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <rule ref="WordPress"/>
+
+    <arg value="sp"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+</ruleset>


### PR DESCRIPTION
This PR introduces a basic `composer.json` and requires the [WordPress Coding Standards for PHP_CodeSniffer](https://github.com/WordPress/WordPress-Coding-Standards) and related dependencies.

The PHP Code Beautifier and Fixer `phpcbf` was run, and the changes were committed.

<details>

Before:

```
FILE: /app/comment-saver.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 48 ERRORS AND 3 WARNINGS AFFECTING 23 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  2 | ERROR   | [ ] You must use "/**" style comments for a file comment (Squiz.Commenting.FileComment.WrongStyle)
 13 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 13 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 14 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 14 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 15 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 15 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 18 | ERROR   | [x] Whitespace found at end of line (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 19 | ERROR   | [x] Whitespace found at end of line (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 22 | WARNING | [ ] parse_url() is discouraged because of inconsistency in the output across PHP versions; use wp_parse_url() instead. (WordPress.WP.AlternativeFunctions.parse_url_parse_url)
 22 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 22 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 22 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 22 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 23 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 2 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 23 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 23 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 28 | ERROR   | [x] Whitespace found at end of line (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 29 | ERROR   | [x] Whitespace found at end of line (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 32 | ERROR   | [x] No space after opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis)
 32 | ERROR   | [ ] is_comments_popup() has been deprecated since WordPress version 4.5.0. (WordPress.WP.DeprecatedFunctions.is_comments_popupFound)
 32 | ERROR   | [x] No space before closing parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis)
 33 | ERROR   | [ ] Version parameter is not explicitly set or has been set to an equivalent of "false" for wp_enqueue_script; This means that the WordPress core version will be used which is not
    |         |     recommended for plugin or theme development. (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
 33 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 33 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 33 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 33 | ERROR   | [x] Missing space after array opener. (WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceAfterArrayOpener)
 33 | ERROR   | [x] Missing space before array closer. (WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceBeforeArrayCloser)
 33 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 38 | ERROR   | [ ] Doc comment for parameter "$id" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 38 | ERROR   | [x] Whitespace found at end of line (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 39 | ERROR   | [x] Whitespace found at end of line (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 41 | ERROR   | [x] No space after opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis)
 41 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen)
 41 | ERROR   | [x] No space before closing parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis)
 41 | ERROR   | [x] Whitespace found at end of line (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 42 | ERROR   | [ ] Variable "$cookieName" is not in valid snake_case format, try "$cookie_name" (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 43 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 7 spaces but found 1 space (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 49 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$cookieName'.
    |         |     (WordPress.Security.EscapeOutput.OutputNotEscaped)
 49 | ERROR   | [ ] Variable "$cookieName" is not in valid snake_case format, try "$cookie_name" (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 49 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$path'.
    |         |     (WordPress.Security.EscapeOutput.OutputNotEscaped)
 52 | ERROR   | [ ] All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$cookieName'.
    |         |     (WordPress.Security.EscapeOutput.OutputNotEscaped)
 52 | ERROR   | [ ] Variable "$cookieName" is not in valid snake_case format, try "$cookie_name" (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 62 | ERROR   | [ ] Doc comment for parameter "$location" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 62 | ERROR   | [ ] Doc comment for parameter "$comment" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 65 | ERROR   | [x] No space after opening parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis)
 65 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen)
 65 | ERROR   | [x] No space before closing parenthesis is prohibited (WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis)
 67 | ERROR   | [x] Expected 1 spaces after opening parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket)
 67 | ERROR   | [x] Expected 1 spaces before closing parenthesis; 0 found (PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket)
 71 | ERROR   | [x] A closing tag is not permitted at the end of a PHP file (PSR2.Files.ClosingTag.NotAllowed)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After:

```
FILE: /app/comment-saver.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 12 ERRORS AND 1 WARNING AFFECTING 9 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  2 | ERROR   | You must use "/**" style comments for a file comment (Squiz.Commenting.FileComment.WrongStyle)
 22 | WARNING | parse_url() is discouraged because of inconsistency in the output across PHP versions; use wp_parse_url() instead. (WordPress.WP.AlternativeFunctions.parse_url_parse_url)
 32 | ERROR   | is_comments_popup() has been deprecated since WordPress version 4.5.0. (WordPress.WP.DeprecatedFunctions.is_comments_popupFound)
 33 | ERROR   | Version parameter is not explicitly set or has been set to an equivalent of "false" for wp_enqueue_script; This means that the WordPress core version will be used which is not recommended
    |         | for plugin or theme development. (WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion)
 38 | ERROR   | Doc comment for parameter "$id" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 42 | ERROR   | Variable "$cookieName" is not in valid snake_case format, try "$cookie_name" (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 49 | ERROR   | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$cookieName'.
    |         | (WordPress.Security.EscapeOutput.OutputNotEscaped)
 49 | ERROR   | Variable "$cookieName" is not in valid snake_case format, try "$cookie_name" (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 49 | ERROR   | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$path'.
    |         | (WordPress.Security.EscapeOutput.OutputNotEscaped)
 52 | ERROR   | All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '$cookieName'.
    |         | (WordPress.Security.EscapeOutput.OutputNotEscaped)
 52 | ERROR   | Variable "$cookieName" is not in valid snake_case format, try "$cookie_name" (WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase)
 62 | ERROR   | Doc comment for parameter "$location" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
 62 | ERROR   | Doc comment for parameter "$comment" missing (Squiz.Commenting.FunctionComment.MissingParamTag)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

</details>

The `phpcs` still shows a few warnings and errors; these will be addressed separately. I didn't want to make the PR unnecessarily large and mix "human" and "non-human" changes.